### PR TITLE
add support for Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM mambaorg/micromamba:0.8.2
+
+RUN apt-get update && \
+    apt-get install -y libgl1-mesa-glx && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+RUN micromamba install -y -n base -c conda-forge -c cadquery \
+    python=3 \
+    cadquery=master \
+    numpy=1 \
+    scipy=1 && \
+    (rm /opt/conda/pkgs/cache/* || true)
+
+SHELL ["micromamba", "run", "-n", "base", "/bin/bash", "-c"]
+WORKDIR /app/src

--- a/docker/run-cadquery
+++ b/docker/run-cadquery
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+cd $(dirname $0)
+
+docker build -t dactyl-keyboard .
+cd ..
+
+docker run -v $(pwd -P):/app dactyl-keyboard python /app/src/dactyl_manuform_cadquery.py 


### PR DESCRIPTION
this PR adds support to run the python scripts in a docker container.

I did have to run through some burning hoops to get cadquery running in the conda environment.

Please let me know if you prefer another solutions.