### PR TITLE
Thumb post fix

### DIFF
--- a/src/dactyl_manuform.py
+++ b/src/dactyl_manuform.py
@@ -97,6 +97,7 @@ if 'HS_' in plate_style:
 mount_width = keyswitch_width + 2 * plate_rim
 mount_height = keyswitch_height + 2 * plate_rim
 mount_thickness = plate_thickness
+double_plate_height = (sa_double_length - mount_height) / 3
 
 if oled_mount_type is not None:
     left_wall_x_offset = oled_left_wall_x_offset_override
@@ -251,8 +252,7 @@ def single_plate(cylinder_segments=100, side="right"):
 ## SA Keycaps ##
 ################
 
-sa_length = 18.25
-sa_double_length = 37.5
+
 
 
 def sa_cap(Usize=1):
@@ -631,10 +631,9 @@ def thumb_15x_layout(shape, cap=False, plate=True):
 
 def double_plate_half():
     debugprint('double_plate()')
-    plate_height = (sa_double_length - mount_height) / 3
-    top_plate = box(mount_width, plate_height, web_thickness)
+    top_plate = box(mount_width, double_plate_height, web_thickness)
     top_plate = translate(top_plate,
-                          [0, (plate_height + mount_height) / 2, plate_thickness - (web_thickness / 2)]
+                          [0, (double_plate_height + mount_height) / 2, plate_thickness - (web_thickness / 2)]
                           )
     return top_plate
 
@@ -688,28 +687,28 @@ def default_thumb(side="right"):
 def thumb_post_tr():
     debugprint('thumb_post_tr()')
     return translate(web_post(),
-                     [(mount_width / 2) - post_adj, (mount_height / 1.15) - post_adj, 0]
+                     [(mount_width / 2) - post_adj, ((mount_height/2) + double_plate_height) - post_adj, 0]
                      )
 
 
 def thumb_post_tl():
     debugprint('thumb_post_tl()')
     return translate(web_post(),
-                     [-(mount_width / 2) + post_adj, (mount_height / 1.15) - post_adj, 0]
+                     [-(mount_width / 2) + post_adj, ((mount_height/2) + double_plate_height) - post_adj, 0]
                      )
 
 
 def thumb_post_bl():
     debugprint('thumb_post_bl()')
     return translate(web_post(),
-                     [-(mount_width / 2) + post_adj, -(mount_height / 1.15) + post_adj, 0]
+                     [-(mount_width / 2) + post_adj, -((mount_height/2) + double_plate_height) + post_adj, 0]
                      )
 
 
 def thumb_post_br():
     debugprint('thumb_post_br()')
     return translate(web_post(),
-                     [(mount_width / 2) - post_adj, -(mount_height / 1.15) + post_adj, 0]
+                     [(mount_width / 2) - post_adj, -((mount_height/2) + double_plate_height) + post_adj, 0]
                      )
 
 

--- a/src/generate_configuration.py
+++ b/src/generate_configuration.py
@@ -113,6 +113,8 @@ shape_config = {
     'notch_width': 5.0, # If using notch, it is identical to undecut, but only locally by the switch clip
 
     'sa_profile_key_height':  12.7,
+    'sa_length': 18.25,
+    'sa_double_length': 37.5,
     'plate_thickness':  4+1.1,
 
     'plate_rim': 1.5 + 0.5,

--- a/src/run_config.json
+++ b/src/run_config.json
@@ -77,6 +77,8 @@
     "undercut_keyswitch_width": 14.0,
     "notch_width": 5.0,
     "sa_profile_key_height": 12.7,
+    "sa_length": 18.25,
+    "sa_double_length": 37.5,
     "plate_thickness": 5.1,
     "plate_rim": 2.0,
     "clip_thickness": 1.4,


### PR DESCRIPTION
I noticed with the addition of plate_rim to the configuration that small voids were created above and below the larger thumb-key plates, starting with commit 7746b12. ![KeyswitchGaps](https://user-images.githubusercontent.com/12849851/125736584-ec70c5b5-04fa-42ad-ac7c-474c25a7e35e.png) This occurred when plate_rim >=1.5, the "original" value used in the plate size calculation. Dependent variables were pulled into the config file + generator, and thumb_post methods adjusted to accurately locate given any rim size. Default config and plate_rim = 1.0, 1.5, 2.0, & 3.0 were tested.

I also think that double_plate_half() method could use some clarity, as it seems to generate a ~1.5u plate and not a 2u, but that is more subjective and a change for another time.