### PR TITLE
add Makefile pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+---
+name: "Dactyl keyboard"
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    name: "Build artifacts and publish Release"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        continue-on-error: true
+      - name: Clean up
+        run: rm -r things/*
+      - name: Build
+        run: make build
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: false
+          files: things/*
+          tag_name: v${{ github.run_number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+#SHELL := /bin/sh
+
+mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+current_dir := $(dir $(mkfile_path))
+
+source_dir := ${current_dir}"src"
+artifact_dir := ${current_dir}"things"
+
+DOCKER_CMD := "docker"
+.DEFAULT_GOAL := help
+
+help: ## Will print this help.
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+.PHONY: help
+
+.DELETE_ON_ERROR:
+
+build: build-container config build-models ## Build everything. Executes the complete pipeline.
+	@echo "\nAll done"
+.PHONY: build
+
+check-requirements: # private
+	@if ! command -v ${DOCKER_CMD} %> /dev/null; then \
+		echo "Docker executable not found (\`${DOCKER_CMD}\`)." && \
+		exit 1; \
+	fi
+.PHONY: check-requirements
+
+build-container: check-requirements ## Build docker container.
+	@echo "\nBuilding container..\n" && \
+	${DOCKER_CMD} build -t dactyl-keyboard -f docker/Dockerfile . && \
+	echo "Done"
+.PHONY: build-container
+
+config: check-requirements ## Generate configuration.
+	@echo "\nGenerate configuration..\n" && \
+	${DOCKER_CMD} run --rm --name DM-config -v ${source_dir}:/app/src -v ${artifact_dir}:/app/things dactyl-keyboard python3 -i generate_configuration.py && \
+	echo "Done"
+.PHONY: config
+
+build-models: check-requirements ## Build models.
+	@echo "\nGenerate models..\n" && \
+	cd ${current_dir} && \
+	${DOCKER_CMD} run --rm --name DM-run -v ${source_dir}:/app/src -v ${artifact_dir}:/app/things dactyl-keyboard python3 -i dactyl_manuform.py && \
+	echo "Done"
+.PHONY: config
+
+shell: check-requirements ## Open an interactive shell inside a container.
+	@${DOCKER_CMD} run --rm -it --name DM-shell -v "src:/app/src" -v "things:/app/things" dactyl-keyboard bash && \
+	echo "\nBye!"
+.PHONY: shell
+


### PR DESCRIPTION
This adds a basic _Makefile_ to help during development/continuous integration.

Execute `make` without any target to get all available commands:
```bash
$ make

help                           Will print this help.
build                          Build everything. Executes the complete pipeline.
build-container                Build docker container 
config                         Generate configuration 
build-models                   Build models
shell                          Open an interactive shell 
```
### Build everything
Just execute
```bash
make build
```
to trigger the main pipeline.

 

This has been tested on a macOS machine and is compatible with a linux shell as well. Sadly I'm not familiar with a Windows env so I'm not sure how does it work there.


~~With a really minor effort is it possible to write a github action to run the `make build` pipeline, collect artifacts and automatically generate and publish a github Release via a github action like https://github.com/marketplace/actions/gh-release :)~~ 
I also created a github Actions workflow to automate the process and publish a github Release on every push on `master` branch :)