### PR TITLE
Restore parameters in `front_wall` to fix the shape

### DIFF
--- a/src/dactyl_manuform.py
+++ b/src/dactyl_manuform.py
@@ -2498,12 +2498,18 @@ def front_wall(skeleton=False):
     print('front_wall()')
     shape = None
 
-    shape = union([shape,key_wall_brace(
-        3, lastrow, 0, -1, web_post_bl(), 3, lastrow, 0.5, -1, web_post_br()
-    )])
-    shape = union([shape,key_wall_brace(
-        3, lastrow, 0.5, -1, web_post_br(), 4, cornerrow, 1, -1, web_post_bl()
-    )])
+    shape = union([
+        shape,
+        key_wall_brace(
+            3, lastrow, 0, -1, web_post_bl(), 3, lastrow, 0, -1,
+            web_post_br())  # Original parameters from the clojure code
+    ])
+    shape = union([
+        shape,
+        key_wall_brace(
+            3, lastrow, 0, -1, web_post_br(), 4, cornerrow, 0, -1,
+            web_post_bl())  # Original parameters from the clojure code
+    ])
     for i in range(ncols - 4):
         x = i + 4
         shape = union([shape,key_wall_brace(


### PR DESCRIPTION
The current `front_wall` will generate an unwanted inner corner.  I compared the parameters with the clojure version to fix this
The unwanted corner:
![defect-front-wall](https://user-images.githubusercontent.com/45414421/141237623-94e08ade-a97e-4b1d-9765-215e9049fa7a.jpg)
Fixed:
![fix-front-wall](https://user-images.githubusercontent.com/45414421/141237646-9a44fa3f-edb6-45e7-b40f-8a529dfbe6cd.jpg)

