### PR TITLE
Monoblock based on left_wall_x_offset

### DIFF
--- a/src/generate_configuration.py
+++ b/src/generate_configuration.py
@@ -467,6 +467,14 @@ shape_config = {
         [0, -6, 5],# NOT USED IN MOST FORMATS (7th column)
     ],
 
+    ###################################
+    ## MONOBLOCK
+    ####################################
+    #    CHECK that 'left_wall_x_offset' fits to 'monoblock_spread'
+    'monoblock': True,
+    'monoblock_spread': 100, # move outside from center: not easy to measure this number: just try...
+    'monoblock_angle': 20,    # angle in degrees for each side out of X-axis
+
 }
 
     ####################################

--- a/src/generate_configuration_mklasklasd.py
+++ b/src/generate_configuration_mklasklasd.py
@@ -464,6 +464,14 @@ shape_config = {
         [0, -6, 5],# NOT USED IN MOST FORMATS (7th column)
     ],
 
+    ###################################
+    ## MONOBLOCK
+    ####################################
+    #    CHECK that 'left_wall_x_offset' fits to 'monoblock_spread'
+    'monoblock': False,
+    'monoblock_spread': 100, # move outside from center: not easy to measure this number: just try...
+    'monoblock_angle': 20,    # angle in degrees for each side out of X-axis
+
 }
 
     ####################################

--- a/src/generate_configuration_orbyl_test.py
+++ b/src/generate_configuration_orbyl_test.py
@@ -459,6 +459,14 @@ shape_config = {
         [0, -6, 5],# NOT USED IN MOST FORMATS (7th column)
     ],
 
+    ###################################
+    ## MONOBLOCK
+    ####################################
+    #    CHECK that 'left_wall_x_offset' fits to 'monoblock_spread'
+    'monoblock': False,
+    'monoblock_spread': 100, # move outside from center: not easy to measure this number: just try...
+    'monoblock_angle': 20,    # angle in degrees for each side out of X-axis
+
 }
 
     ####################################

--- a/src/generate_configuration_test.py
+++ b/src/generate_configuration_test.py
@@ -460,6 +460,14 @@ shape_config = {
         [0, -6, 5],# REDUCED STAGGER
         [0, -6, 5],# NOT USED IN MOST FORMATS (7th column)
     ],
+    
+    ###################################
+    ## MONOBLOCK
+    ####################################
+    #    CHECK that 'left_wall_x_offset' fits to 'monoblock_spread'
+    'monoblock': False,
+    'monoblock_spread': 100, # move outside from center: not easy to measure this number: just try...
+    'monoblock_angle': 20,    # angle in degrees for each side out of X-axis
 
 }
 

--- a/src/run_config.json
+++ b/src/run_config.json
@@ -570,5 +570,8 @@
             -6,
             5
         ]
-    ]
+    ],
+    "monoblock": true,
+    "monoblock_spread": 100,
+    "monoblock_angle": 20
 }


### PR DESCRIPTION
Simplified monoblock approach.

no change of internal wall generation, just exending left wall and cut off.

Therefore  user have to check if left_wall_x_offset is large enough, otherwise warning will raised.

Attention with OLED in the wall.

![image](https://user-images.githubusercontent.com/13511110/164057391-2fae74e5-eb44-4322-96a7-7cefbd7bd168.png)


Myself I also preferer the outcoming result in comparising to #79 