### PR TITLE
Fixes for the PCB_MOUNT controller mount.

### DIFF
--- a/src/dactyl_manuform.py
+++ b/src/dactyl_manuform.py
@@ -3332,7 +3332,7 @@ def trrs_hole():
         (
             trrs_position[0],
             trrs_position[1],
-            trrs_hole_size[0] + pcb_holder_thickness,
+            trrs_position[2],
         )
     )
     return shape

--- a/src/dactyl_manuform.py
+++ b/src/dactyl_manuform.py
@@ -3323,9 +3323,6 @@ def trrs_hole():
     trrs_position[1] = trrs_position[1] + trrs_offset[1]
     trrs_position[2] = trrs_position[2] + trrs_offset[2]
 
-    trrs_hole_size = [3, 20]
-
-
     shape = cylinder(*trrs_hole_size)
     shape = rotate(shape, [0, 90, 90])
     shape = translate(shape,

--- a/src/dactyl_manuform.py
+++ b/src/dactyl_manuform.py
@@ -3193,8 +3193,6 @@ def rj9_holder():
 usb_holder_position = key_position(
     list(np.array(wall_locate2(0, 1)) + np.array([0, (mount_height / 2), 0])), 1, 0
 )
-usb_holder_size = [6.5, 10.0, 13.6]
-usb_holder_thickness = 4
 
 
 def usb_holder():

--- a/src/dactyl_manuform.py
+++ b/src/dactyl_manuform.py
@@ -3275,7 +3275,7 @@ def pcb_usb_hole():
         (
             pcb_usb_position[0],
             pcb_usb_position[1],
-            pcb_usb_hole_size[2] / 2 + usb_holder_thickness,
+            pcb_usb_position[2],
         )
     )
     return shape

--- a/src/generate_configuration.py
+++ b/src/generate_configuration.py
@@ -392,6 +392,9 @@ shape_config = {
 
     # Offset is from the top inner corner of the top inner key.
 
+    "usb_holder_size": [6.5, 10.0, 13.6],
+    "usb_holder_thickness": 4,
+
     ###################################
     ## PCB Screw Mount               ##
     ###################################

--- a/src/generate_configuration.py
+++ b/src/generate_configuration.py
@@ -408,7 +408,7 @@ shape_config = {
     "wall_thinner_size": [34, 7, 10],
 
     "trrs_hole_size": [3, 20],
-    "trrs_offset": [0, 0, 1.5],
+    "trrs_offset": [0, 0, 7],
 
     "pcb_screw_hole_size": [.5, 10],
     "pcb_screw_x_offsets": [- 5.5, 7.75, 22], # for the screw positions off of reference

--- a/src/generate_configuration.py
+++ b/src/generate_configuration.py
@@ -403,7 +403,7 @@ shape_config = {
     "pcb_holder_offset": [8.9, 0, 0],
 
     "pcb_usb_hole_size": [7.5, 10.0, 4],
-    "pcb_usb_hole_offset": [15, 0, 4.5],
+    "pcb_usb_hole_offset": [15, 0, 6],
 
     "wall_thinner_size": [34, 7, 10],
 

--- a/src/run_config.json
+++ b/src/run_config.json
@@ -453,6 +453,12 @@
     "external_holder_width": 28.75,
     "external_holder_xoffset": -5.0,
     "external_holder_yoffset": -4.5,
+    "usb_holder_size": [
+        6.5,
+        10.0,
+        13.6
+    ],
+    "usb_holder_thickness": 4,
     "pcb_mount_ref_offset": [
         0,
         -5,

--- a/src/run_config.json
+++ b/src/run_config.json
@@ -482,7 +482,7 @@
     "pcb_usb_hole_offset": [
         15,
         0,
-        4.5
+        6
     ],
     "wall_thinner_size": [
         34,

--- a/src/run_config.json
+++ b/src/run_config.json
@@ -496,7 +496,7 @@
     "trrs_offset": [
         0,
         0,
-        1.5
+        7
     ],
     "pcb_screw_hole_size": [
         0.5,


### PR DESCRIPTION
A couple of small fixes that should make using the PCB_MOUNT controller_mount_type less surprising:

1. usb_holder_size and usb_holder_thickness information moved to config as multiple calculations are based on those values.
2. Use the TRRS hole size information from the configuration, it was overridden / hardcoded in the trrs_hole() method
3. Use the z-axis offset from configuration for the TRRS hole. Calculating it based on the size of the whole and the thickness of the PCB holder was unexpected and couldn't be manually adjusted. 
4. Use the z-axis offset from the configuration for the USB hole. Same as for the TRRS hole the automatic calculation was unexpected and overriding the configured value.