### PR TITLE
[BUGFIX] Update / pin python dependencies in the conda environment

### DIFF
--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -5,9 +5,10 @@ channels:
   - defaults
 dependencies:
   - python>=3.6
-  - cadquery=2
+  - cadquery=2.1
   - pip
   - numpy
   - scipy
+  - nptyping=1.4.4
   - pip:
     - solidpython


### PR DESCRIPTION
When trying out the docker container I noticed two things which broke
generating models after rebuilding it.

1) Ended up with cadquery 2.2.0b0 which breaks on trackball thumb clusters
   Fixed by explicitly pinning to cadquery 2.1 for now
2) nptyping dependency fails with invalid types on python 3.7/3.8
   Fixed by pinning to nptyping version 1.4.4
