### PR TITLE
[BUGFIX] Fix name of ORBYL trackball cluster in model builder

### DIFF
--- a/src/model_builder.py
+++ b/src/model_builder.py
@@ -24,7 +24,7 @@ config_options = [
     },
     {
         'name': '{}TMB', 'vars': ['thumb_style'],
-        'vals': ['DEFAULT', 'MINIDOX', 'TRACKBALL_ORBISSYL'],
+        'vals': ['DEFAULT', 'MINIDOX', 'TRACKBALL_ORBYL'],
         'val_names': ['DEF', 'MDOX', 'ORBY']
         # 'vals': ['DEFAULT', 'MINI', 'CARBONFET', 'MINIDOX'],
         # 'val_names': ['DEF', 'MINI', 'CF', 'MDOX']


### PR DESCRIPTION
Looks like it was missed to rename the thumb style in the model builder, causing failures at runtime.
