### PR TITLE
Solely use numpy for trig functions.

### DIFF
--- a/src/clusters/carbonfet.py
+++ b/src/clusters/carbonfet.py
@@ -1,12 +1,10 @@
 import json
 import os
-import numpy as np
 from dataclasses_json import dataclass_json
 from dataclasses import dataclass
 from dataclasses_json import dataclass_json
 from dataclasses import dataclass
 import clusters.cluster_abc as ca
-from dactyl_manuform import rad2deg, pi
 from typing import Any, Sequence
 
 def debugprint(data):
@@ -81,7 +79,7 @@ class CarbonfetCluster(ca.ClusterBase):
 
     def thumbcaps(self):
         t1 = self.thumb_1x_layout(self.pl.sa_cap(1))
-        t15 = self.thumb_15x_layout(self.g.rotate(self.pl.sa_cap(1.5), [0, 0, rad2deg(pi / 2)]))
+        t15 = self.thumb_15x_layout(self.g.rotate(self.pl.sa_cap(1.5), [0, 0, 90]))
         return t1.add(t15)
 
     def thumb(self):

--- a/src/clusters/cluster_abc.py
+++ b/src/clusters/cluster_abc.py
@@ -1,6 +1,5 @@
 import json
 import os
-import numpy as np
 from dataclasses_json import dataclass_json
 from dataclasses import dataclass
 from abc import ABC

--- a/src/clusters/default.py
+++ b/src/clusters/default.py
@@ -1,10 +1,8 @@
 import json
 import os
-import numpy as np
 from dataclasses_json import dataclass_json
 from dataclasses import dataclass
 import clusters.cluster_abc as ca
-from dactyl_manuform import rad2deg, pi
 from typing import Any, Sequence
 
 def debugprint(data):

--- a/src/clusters/mini.py
+++ b/src/clusters/mini.py
@@ -4,9 +4,7 @@ import os
 from dataclasses_json import dataclass_json
 from dataclasses import dataclass
 import clusters.cluster_abc as ca
-from dactyl_manuform import rad2deg, pi
 from typing import Any, Sequence
-import numpy as np
 
 def debugprint(data):
     pass
@@ -98,7 +96,7 @@ class MiniCluster(ca.ClusterBase):
 
     def thumbcaps(self):
         t1 = self.thumb_1x_layout(self.pl.sa_cap(1))
-        t15 = self.thumb_15x_layout(self.g.rotate(self.pl.sa_cap(1), [0, 0, rad2deg(pi / 2)]))
+        t15 = self.thumb_15x_layout(self.g.rotate(self.pl.sa_cap(1), [0, 0, 90]))
         return t1.add(t15)
 
     def thumb(self):

--- a/src/clusters/minidox.py
+++ b/src/clusters/minidox.py
@@ -1,11 +1,9 @@
 from clusters.default import DefaultCluster
 import os
 import json
-import numpy as np
 from dataclasses_json import dataclass_json
 from dataclasses import dataclass
 import clusters.cluster_abc as ca
-from dactyl_manuform import rad2deg, pi
 from typing import Any, Sequence
 
 def debugprint(data):

--- a/src/clusters/trackball_cj.py
+++ b/src/clusters/trackball_cj.py
@@ -1,11 +1,9 @@
 import json
 import os
-import math
 import numpy as np
 from dataclasses_json import dataclass_json
 from dataclasses import dataclass
 import clusters.trackball_cluster_abc as ca
-from dactyl_manuform import rad2deg, pi
 from typing import Any, Sequence
 
 def debugprint(data):
@@ -69,7 +67,7 @@ class TrackballCJCluster(ca.TrackballClusterBase):
         i = (i + 1) % 8
 
         r = radius
-        m = radius * math.tan(math.pi / 8)
+        m = radius * np.tan(np.pi / 8)
 
         points_x = [m, r, r, m, -m, -r, -r, -m]
         points_y = [r, m, -m, -r, -r, -m, m, r]

--- a/src/clusters/trackball_orbyl.py
+++ b/src/clusters/trackball_orbyl.py
@@ -1,11 +1,9 @@
 from clusters.default import DefaultCluster
 import json
 import os
-import numpy as np
 from dataclasses_json import dataclass_json
 from dataclasses import dataclass
 import clusters.trackball_cluster_abc as ca
-from dactyl_manuform import rad2deg, pi
 from typing import Any, Sequence
 
 def debugprint(data):

--- a/src/clusters/trackball_wilder.py
+++ b/src/clusters/trackball_wilder.py
@@ -1,8 +1,6 @@
-import numpy as np
 from dataclasses_json import dataclass_json
 from dataclasses import dataclass
 import clusters.trackball_orbyl as tbob
-from dactyl_manuform import rad2deg, pi
 from typing import Any, Sequence
 
 def debugprint(data):

--- a/src/dactyl_manuform.py
+++ b/src/dactyl_manuform.py
@@ -1,5 +1,4 @@
 import numpy as np
-from numpy import pi
 import os.path as path
 import os
 import copy
@@ -40,15 +39,6 @@ debug_trace = False
 def debugprint(info):
     if debug_trace:
         print(info)
-
-
-
-def deg2rad(degrees: float) -> float:
-    return degrees * pi / 180
-
-
-def rad2deg(rad: float) -> float:
-    return rad * 180 / pi
 
 
 def usize_dimension(Usize=1.5):
@@ -310,11 +300,11 @@ class DactylBase:
 
     def x_rot(self, shape, angle):
         # debugprint('x_rot()')
-        return self.g.rotate(shape, [rad2deg(angle), 0, 0])
+        return self.g.rotate(shape, [np.rad2deg(angle), 0, 0])
 
     def y_rot(self, shape, angle):
         # debugprint('y_rot()')
-        return self.g.rotate(shape, [0, rad2deg(angle), 0])
+        return self.g.rotate(shape, [0, np.rad2deg(angle), 0])
 
     def key_place(self, shape, column, row):
         debugprint('key_place()')

--- a/src/default_configuration.py
+++ b/src/default_configuration.py
@@ -1,3 +1,4 @@
+import numpy as np
 import sys
 import getopt
 import os
@@ -5,10 +6,6 @@ import json
 from dataclasses_json import dataclass_json
 from dataclasses import dataclass
 from typing import Any, Sequence
-
-pi = 3.14159
-d2r = pi / 180
-r2d = 180 / pi
 
 from oled.oled_clip import OLEDClipParameters as OLEDClip
 from oled.oled_sliding import OLEDSlidingParameters as OLEDSliding
@@ -41,11 +38,11 @@ class ShapeConfiguration:
     nrows = 5  # 5,  # key rows
     ncols = 6  # 6,  # key columns
 
-    alpha: float = pi / 12.0  # curvature of the columns
-    beta: float = pi / 36.0  # curvature of the rows
+    alpha: float = np.pi / 12.0  # curvature of the columns
+    beta: float = np.pi / 36.0  # curvature of the rows
     centercol: int = 3  # controls left_right tilt / tenting (higher number is more tenting)
     centerrow_offset: int = 3  # rows from max, controls front_back tilt
-    tenting_angle: float = pi / 12.0  # or, change this for more precise tenting control
+    tenting_angle: float = np.pi / 12.0  # or, change this for more precise tenting control
 
     # symmetry states if it is a symmetric or asymmetric bui.  If asymmetric it doubles the generation time.
     symmetric: bool = True # "asymmetric" or "symmetric"
@@ -136,10 +133,10 @@ class ShapeConfiguration:
     ##   http://patentimages.storage.googleapis.com/EP0219944A2/imgf0002.png
     ## fixed_z overrides the z portion of the column ofsets above.
     ## NOTE: THIS DOESN'T WORK QUITE LIKE I'D HOPED.
-    fixed_angles: Sequence[float] = (d2r * 10, d2r * 10, 0, 0, 0, d2r * -15, d2r * -15)
+    fixed_angles: Sequence[float] = tuple(np.deg2rad((10, 10, 0, 0, 0, -15, -15)))
     fixed_x: Sequence[float] = (-41.5, -22.5, 0, 20.3, 41.4, 65.5, 89.6)  # relative to the middle finger
     fixed_z: Sequence[float] = (12.1, 8.3, 0, 5, 10.7, 14.5, 17.5)
-    fixed_tenting: float = d2r * 0
+    fixed_tenting: float = np.deg2rad(0)
 
     ###################################
     ## SCREWS SETUP                  ##

--- a/src/generate_configuration.py
+++ b/src/generate_configuration.py
@@ -1,12 +1,9 @@
+import numpy as np
 import sys
 import getopt
 import os
 import json
 
-
-pi = 3.14159
-d2r = pi / 180
-r2d = 180 / pi
 
 shape_config = {
 
@@ -27,11 +24,11 @@ shape_config = {
     'nrows':  5, #5,  # key rows
     'ncols':  3, #6,  # key columns
 
-    'alpha':  pi / 12.0,  # curvature of the columns
-    'beta':  pi / 36.0,  # curvature of the rows
+    'alpha':  np.pi / 12.0,  # curvature of the columns
+    'beta':  np.pi / 36.0,  # curvature of the rows
     'centercol':  3,  # controls left_right tilt / tenting (higher number is more tenting)
     'centerrow_offset':  3,  # rows from max, controls front_back tilt
-    'tenting_angle':  pi / 12.0,  # or, change this for more precise tenting control
+    'tenting_angle':  np.pi / 12.0,  # or, change this for more precise tenting control
 
     # symmetry states if it is a symmetric or asymmetric bui.  If asymmetric it doubles the generation time.
     'symmetry':  "symmetric",  # "asymmetric" or "symmetric"
@@ -213,10 +210,10 @@ shape_config = {
     ##   http://patentimages.storage.googleapis.com/EP0219944A2/imgf0002.png
     ## fixed_z overrides the z portion of the column ofsets above.
     ## NOTE: THIS DOESN'T WORK QUITE LIKE I'D HOPED.
-    'fixed_angles':  [d2r * 10, d2r * 10, 0, 0, 0, d2r * -15, d2r * -15],
+    'fixed_angles':  list(np.deg2rad([10, 10, 0, 0, 0, -15, -15])),
     'fixed_x':  [-41.5, -22.5, 0, 20.3, 41.4, 65.5, 89.6],  # relative to the middle finger
     'fixed_z':  [12.1, 8.3, 0, 5, 10.7, 14.5, 17.5],
-    'fixed_tenting':  d2r * 0,
+    'fixed_tenting':  np.deg2rad(0),
 
     #################
     ## Switch Hole ##

--- a/src/generate_configuration_orbyl_test.py
+++ b/src/generate_configuration_orbyl_test.py
@@ -3,11 +3,6 @@ import getopt
 import os
 import json
 
-
-pi = 3.14159
-d2r = pi / 180
-r2d = 180 / pi
-
 shape_config = {
 
     'ENGINE': 'solid',  # 'solid' = solid python / OpenSCAD, 'cadquery' = cadquery / OpenCascade
@@ -208,10 +203,10 @@ shape_config = {
     ##   http://patentimages.storage.googleapis.com/EP0219944A2/imgf0002.png
     ## fixed_z overrides the z portion of the column ofsets above.
     ## NOTE: THIS DOESN'T WORK QUITE LIKE I'D HOPED.
-    'fixed_angles':  [d2r * 10, d2r * 10, 0, 0, 0, d2r * -15, d2r * -15],
+    'fixed_angles':  list(np.deg2rad([10, 10, 0, 0, 0, -15, -15])),
     'fixed_x':  [-41.5, -22.5, 0, 20.3, 41.4, 65.5, 89.6],  # relative to the middle finger
     'fixed_z':  [12.1, 8.3, 0, 5, 10.7, 14.5, 17.5],
-    'fixed_tenting':  d2r * 0,
+    'fixed_tenting':  np.deg2rad(0),
 
     #################
     ## Switch Hole ##

--- a/src/generate_configuration_test.py
+++ b/src/generate_configuration_test.py
@@ -1,12 +1,9 @@
+import numpy as np
 import sys
 import getopt
 import os
 import json
 
-
-pi = 3.14159
-d2r = pi / 180
-r2d = 180 / pi
 
 shape_config = {
 
@@ -27,11 +24,11 @@ shape_config = {
     'nrows':  5, #5,  # key rows
     'ncols':  6, #6,  # key columns
 
-    'alpha':  pi / 12.0,  # curvature of the columns
-    'beta':  pi / 36.0,  # curvature of the rows
+    'alpha':  np.pi / 12.0,  # curvature of the columns
+    'beta':  np.pi / 36.0,  # curvature of the rows
     'centercol':  3,  # controls left_right tilt / tenting (higher number is more tenting)
     'centerrow_offset': 3,  # rows from max, controls front_back tilt
-    'tenting_angle':  pi / 12.0,  # or, change this for more precise tenting control
+    'tenting_angle':  np.pi / 12.0,  # or, change this for more precise tenting control
 
     # symmetry states if it is a symmetric or asymmetric bui.  If asymmetric it doubles the generation time.
     'symmetry':  "symmetric",  # "asymmetric" or "symmetric"
@@ -210,10 +207,10 @@ shape_config = {
     ##   http://patentimages.storage.googleapis.com/EP0219944A2/imgf0002.png
     ## fixed_z overrides the z portion of the column ofsets above.
     ## NOTE: THIS DOESN'T WORK QUITE LIKE I'D HOPED.
-    'fixed_angles':  [d2r * 10, d2r * 10, 0, 0, 0, d2r * -15, d2r * -15],
+    'fixed_angles':  list(np.deg2rad([10, 10, 0, 0, 0, -15, -15])),
     'fixed_x':  [-41.5, -22.5, 0, 20.3, 41.4, 65.5, 89.6],  # relative to the middle finger
     'fixed_z':  [12.1, 8.3, 0, 5, 10.7, 14.5, 17.5],
-    'fixed_tenting':  d2r * 0,
+    'fixed_tenting':  np.deg2rad(0),
 
     #################
     ## Switch Hole ##

--- a/src/helpers/helpers_abc.py
+++ b/src/helpers/helpers_abc.py
@@ -1,6 +1,5 @@
 import cadquery as cq
 from scipy.spatial import ConvexHull as sphull
-import numpy as np
 
 
 debug_trace = False

--- a/src/helpers/helpers_blender.py
+++ b/src/helpers/helpers_blender.py
@@ -1,10 +1,10 @@
+import numpy as np
 import bpy
 import bmesh
 import os
 import sys
 import time
 import mathutils
-from math import pi, radians, sin, cos
 from contextlib import contextmanager
 
 
@@ -34,9 +34,9 @@ def cone(r1, r2, height):
 
 
 def rotate(shape, angle):
-    bpy.ops.transform.rotate(value=-radians(angle[0]), orient_axis='X', center_override=(0.0, 0.0, 0.0))
-    bpy.ops.transform.rotate(value=-radians(angle[1]), orient_axis='Y', center_override=(0.0, 0.0, 0.0))
-    bpy.ops.transform.rotate(value=-radians(angle[2]), orient_axis='Z', center_override=(0.0, 0.0, 0.0))
+    bpy.ops.transform.rotate(value=-np.deg2rad(angle[0]), orient_axis='X', center_override=(0.0, 0.0, 0.0))
+    bpy.ops.transform.rotate(value=-np.deg2rad(angle[1]), orient_axis='Y', center_override=(0.0, 0.0, 0.0))
+    bpy.ops.transform.rotate(value=-np.deg2rad(angle[2]), orient_axis='Z', center_override=(0.0, 0.0, 0.0))
     return
 
 def translate(shape, vector):

--- a/src/oled/oled_abc.py
+++ b/src/oled/oled_abc.py
@@ -11,8 +11,6 @@ def debugprint(data):
     pass
     # print
 
-def rad2deg(rad: float) -> float:
-    return rad * 180 / 3.14159
 
 @dataclass_json
 @dataclass
@@ -104,7 +102,7 @@ class OLEDBase(ABC):
             angle_x = np.arctan2(base_pt1[2] - base_pt2[2], base_pt1[1] - base_pt2[1])
             angle_z = np.arctan2(base_pt1[0] - base_pt2[0], base_pt1[1] - base_pt2[1])
 
-            self.op.mount_rotation_xyz = (rad2deg(angle_x), 0, -rad2deg(angle_z)) + np.array(
+            self.op.mount_rotation_xyz = np.rad2deg((angle_x, 0, -angle_z)) + np.array(
                 self.op.rotation_offset)
 
 
@@ -133,9 +131,9 @@ class OLEDBase(ABC):
             angle_z = np.arctan2(base_pt1[0] - base_pt2[0], base_pt1[1] - base_pt2[1])
 
             if self.op.vertical:
-                oled_mount_rotation_xyz = (rad2deg(angle_x), 0, -rad2deg(angle_z)) + np.array(self.op.rotation_offset)
+                oled_mount_rotation_xyz = np.rad2deg((angle_x, 0, -angle_z)) + np.array(self.op.rotation_offset)
             else:
-                oled_mount_rotation_xyz = (0, rad2deg(angle_x), -90) + np.array(self.op.rotation_offset)
+                oled_mount_rotation_xyz = (0, np.rad2deg(angle_x), -90) + np.array(self.op.rotation_offset)
 
             return oled_mount_location_xyz, oled_mount_rotation_xyz
 

--- a/src/oled/oled_clip.py
+++ b/src/oled/oled_clip.py
@@ -1,6 +1,5 @@
 import json
 from os import path
-import numpy as np
 from dataclasses_json import dataclass_json
 from dataclasses import dataclass
 from typing import Any, Sequence, Tuple, Optional
@@ -9,9 +8,6 @@ import oled.oled_abc as oa
 def debugprint(data):
     pass
     # print
-
-def rad2deg(rad: float) -> float:
-    return rad * 180 / pi
 
 @dataclass_json
 @dataclass

--- a/src/oled/oled_sliding.py
+++ b/src/oled/oled_sliding.py
@@ -1,6 +1,5 @@
 import json
 import os
-import numpy as np
 from dataclasses_json import dataclass_json
 from dataclasses import dataclass
 from typing import Any, Sequence, Tuple, Optional
@@ -9,9 +8,6 @@ import oled.oled_abc as oa
 def debugprint(data):
     pass
     # print
-
-def rad2deg(rad: float) -> float:
-    return rad * 180 / 3.14159
 
 
 @dataclass_json

--- a/src/oled/oled_undercut.py
+++ b/src/oled/oled_undercut.py
@@ -1,6 +1,5 @@
 import json
 from os import path
-import numpy as np
 from dataclasses_json import dataclass_json
 from dataclasses import dataclass
 from typing import Any, Sequence, Tuple
@@ -9,9 +8,6 @@ import oled.oled_abc as oa
 def debugprint(data):
     pass
     # print
-
-def rad2deg(rad: float) -> float:
-    return rad * 180 / 3.14159
 
 
 @dataclass_json

--- a/src/shapes/plates.py
+++ b/src/shapes/plates.py
@@ -4,7 +4,6 @@
 # import copy
 # import importlib
 from helpers import helpers_abc
-from math import pi
 from dataclasses_json import dataclass_json
 from dataclasses import dataclass
 import os.path as path
@@ -90,13 +89,6 @@ from typing import Any, Sequence, Tuple, Optional
 # ]
 
 debug_trace=False
-
-def deg2rad(degrees: float) -> float:
-    return degrees * pi / 180
-
-
-def rad2deg(rad: float) -> float:
-    return rad * 180 / pi
 
 
 def usize_dimension(Usize=1.5):

--- a/src/shapes/trackball_in_wall.py
+++ b/src/shapes/trackball_in_wall.py
@@ -13,11 +13,6 @@ def debugprint(data):
     pass
     # print
 
-
-def rad2deg(rad: float) -> float:
-    return rad * 180 / 3.14159
-
-
 @dataclass_json
 @dataclass
 class TBIWParameters:
@@ -100,7 +95,7 @@ class Trackball_in_wall:
 
         angle_x = np.arctan2(base_pt1[2] - base_pt2[2], base_pt1[1] - base_pt2[1])
         angle_z = np.arctan2(base_pt1[0] - base_pt2[0], base_pt1[1] - base_pt2[1])
-        tbiw_mount_rotation_xyz = (rad2deg(angle_x), 0, rad2deg(angle_z)) + np.array(self.p.tbiw_rotation_offset)
+        tbiw_mount_rotation_xyz = np.rad2deg((angle_x, 0, angle_z)) + np.array(self.p.tbiw_rotation_offset)
 
         return tbiw_mount_location_xyz, tbiw_mount_rotation_xyz
 

--- a/src/workflow/builder.py
+++ b/src/workflow/builder.py
@@ -1,7 +1,5 @@
 # from dactyl_manuform import *
 from clusters.default import DefaultCluster
-import numpy as np
-from numpy import pi
 import os.path as path
 import getopt, sys
 import json
@@ -11,13 +9,6 @@ import shutil
 
 debug_exports = False
 debug_trace = False
-
-def deg2rad(degrees: float) -> float:
-    return degrees * pi / 180
-
-
-def rad2deg(rad: float) -> float:
-    return rad * 180 / pi
 
 
 def debugprint(info):


### PR DESCRIPTION
Remove use of `math` module in preference for numpy definitions, for consistency. 
Remove all in-module conversion and value definitions relating to radian/degree conversions. 
Clean up related unused imports.