### PR TITLE
Fix: DispatchError: extrudeLinear 0 methods found

### DIFF
--- a/src/dactyl_manuform.py
+++ b/src/dactyl_manuform.py
@@ -4261,7 +4261,7 @@ def baseplate(wedge_angle=None, side='right'):
         if wedge_angle is not None:
             cq.Workplane('XY').add(cq.Solid.revolve(outerWire, innerWires, angleDegrees, axisStart, axisEnd))
         else:
-            inner_shape = cq.Workplane('XY').add(cq.Solid.extrudeLinear(outerWire=inner_wire, innerWires=[], vecNormal=cq.Vector(0, 0, base_thickness)))
+            inner_shape = cq.Workplane('XY').add(cq.Solid.extrudeLinear(inner_wire, [], cq.Vector(0, 0, base_thickness)))
             inner_shape = translate(inner_shape, (0, 0, -base_rim_thickness))
 
             holes = []

--- a/src/helpers_cadquery.py
+++ b/src/helpers_cadquery.py
@@ -217,7 +217,7 @@ def extrude_poly(outer_poly, inner_polys=None, height=1):  # vector=(0,0,1)):
             inner_wires.append(cq.Wire.assembleEdges(item.edges().objects))
 
     return cq.Workplane('XY').add(
-        cq.Solid.extrudeLinear(outerWire=outer_wires, innerWires=inner_wires, vecNormal=cq.Vector(0, 0, height)))
+        cq.Solid.extrudeLinear(outer_wires, inner_wires, cq.Vector(0, 0, height)))
 
 
 def import_file(fname, convexity=None):


### PR DESCRIPTION
After using the latest docker file #115 and cadquery I got the following error message:
`"DispatchError: ('extrudeLinear: 0 methods found'`
as mentioned in: https://groups.google.com/g/cadquery/c/Zk1GuvDjkOE

This fixes that..