### PR TITLE
Fix pcb_clearance list error

### DIFF
--- a/src/dactyl_manuform.py
+++ b/src/dactyl_manuform.py
@@ -4100,7 +4100,7 @@ def model_side(side="right"):
             shape = add([shape, ball])
 
     if plate_pcb_clear:
-        shape = difference(shape, [plate_pcb_cutouts(side=side)])
+        shape = difference(shape, plate_pcb_cutouts(side=side))
 
     main_shape = shape
 


### PR DESCRIPTION
Before this pr, setting `"plate_pcb_clear": true` resulted in:

ValueError: Cannot cut type '<class 'list'>'

screw_insert_all_shapes()
Traceback (most recent call last):
  File "/app/src/dactyl_manuform.py", line 4361, in <module>
    run()
  File "/app/src/dactyl_manuform.py", line 4314, in run
    mod_r, tmb_r = model_side(side="right")
  File "/app/src/dactyl_manuform.py", line 4104, in model_side
    shape = difference(shape, [plate_pcb_cutouts(side=side)])
  File "/app/src/helpers_cadquery.py", line 89, in difference
    shape = shape.cut(item)
  File "/opt/conda/envs/myenv/lib/python3.10/site-packages/cadquery/cq.py", line 3360, in cut
    raise ValueError("Cannot cut type '{}'".format(type(toCut)))
ValueError: Cannot cut type '<class 'list'>'